### PR TITLE
add Tile layer in pacman

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -358,6 +358,8 @@ GameObject:
   - component: {fileID: 1717289517}
   - component: {fileID: 1717289516}
   - component: {fileID: 1717289515}
+  - component: {fileID: 1717289519}
+  - component: {fileID: 1717289518}
   m_Layer: 0
   m_Name: PACMAN_0
   m_TagString: Untagged
@@ -453,6 +455,31 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1717289518
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1717289514}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0b25d8b94fe76534b98018eccff5f3f9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1717289519
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1717289514}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 232fdf7497aa08d46a972a18eeb106b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  moveTime: 0.2
 --- !u!1 &1962847383
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
player object안에 Tile을 인식할 수 있게 "Tile" Layer를 추가하였습니다.
하지만 아직 맵 제작이 끝나지 않아 플레이어가의 타일충돌 코드를 짜지는 못할 것 같습니다.